### PR TITLE
Implement AfmeldenJob SOAP service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.cxf</groupId>
+            <artifactId>quarkus-cxf</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
@@ -46,6 +50,11 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.cxf</groupId>
+            <artifactId>quarkus-cxf-test-util</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/nl/cge/b2z/soap/AfmeldenJobService.java
+++ b/src/main/java/nl/cge/b2z/soap/AfmeldenJobService.java
@@ -1,0 +1,11 @@
+package nl.cge.b2z.soap;
+
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebService;
+
+@WebService(name = "AfmeldenJobService", serviceName = "AfmeldenJobService")
+public interface AfmeldenJobService {
+
+    @WebMethod
+    String afmeldenJob(Integer jobId);
+}

--- a/src/main/java/nl/cge/b2z/soap/AfmeldenJobServiceImpl.java
+++ b/src/main/java/nl/cge/b2z/soap/AfmeldenJobServiceImpl.java
@@ -1,0 +1,12 @@
+package nl.cge.b2z.soap;
+
+import jakarta.jws.WebService;
+
+@WebService(serviceName = "AfmeldenJobService", endpointInterface = "nl.cge.b2z.soap.AfmeldenJobService")
+public class AfmeldenJobServiceImpl implements AfmeldenJobService {
+
+    @Override
+    public String afmeldenJob(Integer jobId) {
+        return "Job " + jobId + " afgemeld";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.cxf.path = /soap
+quarkus.cxf.endpoint."/afmeldenJob".implementor = nl.cge.b2z.soap.AfmeldenJobServiceImpl
+quarkus.cxf.endpoint."/afmeldenJob".logging.enabled = pretty

--- a/src/test/java/nl/cge/b2z/soap/AfmeldenJobServiceIT.java
+++ b/src/test/java/nl/cge/b2z/soap/AfmeldenJobServiceIT.java
@@ -1,0 +1,8 @@
+package nl.cge.b2z.soap;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class AfmeldenJobServiceIT extends AfmeldenJobServiceTest {
+    // executes the same tests in native mode
+}

--- a/src/test/java/nl/cge/b2z/soap/AfmeldenJobServiceTest.java
+++ b/src/test/java/nl/cge/b2z/soap/AfmeldenJobServiceTest.java
@@ -1,0 +1,17 @@
+package nl.cge.b2z.soap;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.cxf.test.QuarkusCxfClientTestUtil;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class AfmeldenJobServiceTest {
+
+    @Test
+    void afmeldenJob() {
+        AfmeldenJobService client = QuarkusCxfClientTestUtil.getClient(AfmeldenJobService.class, "/soap/afmeldenJob");
+        Assertions.assertEquals("Job 1 afgemeld", client.afmeldenJob(1));
+    }
+}


### PR DESCRIPTION
## Summary
- add Quarkus CXF dependency for SOAP support
- implement `AfmeldenJobService` SOAP interface and implementation
- expose SOAP endpoint via application properties
- test SOAP service with QuarkusCxfClientTestUtil

## Testing
- `mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686c2884ced08331823b0a65fec59be0